### PR TITLE
Update AWS SDK version

### DIFF
--- a/atlas.gemspec
+++ b/atlas.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
 
   spec.add_dependency 'activesupport'
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk', '~> 3'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'delayed_job'
   spec.add_dependency 'delayed_job_mongoid'

--- a/lib/atlas/version.rb
+++ b/lib/atlas/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Atlas
-  VERSION = '0.22.0'
+  VERSION = '0.22.1'
 end


### PR DESCRIPTION
In order to use AWS SQS, we must update AWS SDK dependencie to version 3.